### PR TITLE
時間制御

### DIFF
--- a/mt-dashboard-backend/mt_dashboard_backend/api/routes/time_restriction_routes.py
+++ b/mt-dashboard-backend/mt_dashboard_backend/api/routes/time_restriction_routes.py
@@ -8,8 +8,8 @@ router = APIRouter()
 async def check_access_time():
     """
     現在時刻がアクセス許可時間内かをチェック
-    許可時間: 11:05:00-24:00:00 (JST)
-    制限時間: 00:00:01-11:04:59 (JST)
+    許可時間: 10:00:00-24:00:00 (JST)
+    制限時間: 00:00:01-09:59:59 (JST)
     UTC時刻から日本時刻を計算（本番環境では完全に独立）
     """
     # UTC時刻を取得してJST（UTC+9）に変換
@@ -19,28 +19,22 @@ async def check_access_time():
     current_minute = jst_now.minute
     current_second = jst_now.second
     
-    # 11:05:00-24:00:00の間かチェック（秒単位で正確）
-    # 許可: 11:05:00以降 または 00:00:00ちょうど
-    # 制限: 00:00:01-11:04:59
+    # 10:00:00-24:00:00の間かチェック（秒単位で正確）
+    # 許可: 10:00:00以降 または 00:00:00ちょうど
+    # 制限: 00:00:01-09:59:59
     
-    if current_hour >= 12:
-        # 12時以降は許可
-        is_allowed = True
-    elif current_hour == 11 and current_minute >= 5:
-        # 11時05分以降は許可
+    if current_hour >= 10:
+        # 10時以降は許可
         is_allowed = True
     elif current_hour == 0 and current_minute == 0 and current_second == 0:
         # 00:00:00ちょうど（24:00:00）は許可
         is_allowed = True
-    elif current_hour >= 1 and current_hour <= 10:
-        # 1時台-10時台は制限
-        is_allowed = True # 本番環境ではFalse
-    elif current_hour == 11 and current_minute < 5:
-        # 11時台だが5分未満は制限
-        is_allowed = True # 本番環境ではFalse
+    elif current_hour >= 1 and current_hour <= 9:
+        # 1時台-9時台は制限
+        is_allowed = False
     elif current_hour == 0:
         # 0時台（但し00:00:00以外）は制限
-        is_allowed = True # 本番環境ではFalse
+        is_allowed = False
     else:
         # その他は許可（念のため）
         is_allowed = True
@@ -51,8 +45,8 @@ async def check_access_time():
         "current_hour": current_hour,
         "current_minute": current_minute,
         "current_second": current_second,
-        "allowed_hours": "11:05:00-24:00:00 (JST)",
-        "restricted_hours": "00:00:01-11:04:59 (JST)",
+        "allowed_hours": "10:00:00-24:00:00 (JST)",
+        "restricted_hours": "00:00:01-09:59:59 (JST)",
         "message": "アクセス可能" if is_allowed else "アクセス制限時間です",
         "environment": "production" if utc_now.hour != datetime.now().hour else "development"
     } 

--- a/mt-dashboard-frontend/src/App.tsx
+++ b/mt-dashboard-frontend/src/App.tsx
@@ -667,7 +667,7 @@ function MainContent() {
         <Routes>
           <Route path="/" element={<LandingPage />} />
           <Route path="/login" element={<Login />} />
-          <Route path="/register" element={<Register />} />
+          <Route path="/register" element={<Navigate to="/" replace />} />
           <Route
             path="/dashboard"
             element={

--- a/mt-dashboard-frontend/src/components/CashTransaction/CashTransactionForm.tsx
+++ b/mt-dashboard-frontend/src/components/CashTransaction/CashTransactionForm.tsx
@@ -1,9 +1,10 @@
 // src/components/CashTransaction/CashTransactionForm.tsx
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { CircularProgress, useMediaQuery, useTheme } from '@mui/material';
 import ConfirmationModal from './ConfirmationModal';
 import { useAuth } from '../../contexts/AuthContext';
+import { isTransactionButtonVisible } from '../../utils/timeRestriction';
 
 interface Metal {
   name: string;
@@ -52,6 +53,19 @@ const CashTransactionForm: React.FC<CashTransactionFormProps> = ({ metals, onSal
   const [totalAmount, setTotalAmount] = useState<number>(0);
   const [isConfirmationOpen, setIsConfirmationOpen] = useState(false);
   const [isProcessing, setIsProcessing] = useState(false);
+  const [showTransactionButton, setShowTransactionButton] = useState(false);
+
+  // 時間制限チェックを定期的に実行
+  useEffect(() => {
+    const checkButtonVisibility = () => {
+      setShowTransactionButton(isTransactionButtonVisible());
+    };
+
+    checkButtonVisibility(); // 初回チェック
+    const interval = setInterval(checkButtonVisibility, 60000); // 1分ごとにチェック
+
+    return () => clearInterval(interval);
+  }, []);
 
   const formatPrice = (price: number) => {
     if (price === 0) return '0円';
@@ -371,17 +385,20 @@ const CashTransactionForm: React.FC<CashTransactionFormProps> = ({ metals, onSal
             >
               計算
             </button>
-            <button
-              onClick={handleProceed}
-              className="px-4 py-2 bg-emerald-600 text-white rounded hover:bg-emerald-700"
-            >
-              売却手続きへ
-            </button>
+            {showTransactionButton && (
+              <button
+                onClick={handleProceed}
+                className="px-4 py-2 bg-emerald-600 text-white rounded hover:bg-emerald-700"
+              >
+                売却手続きへ
+              </button>
+            )}
           </div>
         </div>
       </div>
       
       <div className="mt-2 text-left text-gray-500 text-xl font-bold">※上記価格は消費税は含まれておりません</div>
+      <div className="mt-1 text-left text-gray-500 text-xl font-bold">※現金決済は10:00〜12:30、14:30〜15:30の時間帯のみ利用可能です</div>
       
       <ConfirmationModal
         isOpen={isConfirmationOpen}

--- a/mt-dashboard-frontend/src/components/CashTransaction/TransactionHistory.tsx
+++ b/mt-dashboard-frontend/src/components/CashTransaction/TransactionHistory.tsx
@@ -35,6 +35,9 @@ const TransactionHistory: React.FC<Props> = ({ transactions, onTransactionUpdate
   const [currentTransactionId, setCurrentTransactionId] = useState<string>('');
   const [resultMessage, setResultMessage] = useState<{type: 'success' | 'error', text: string} | null>(null);
 
+  // キャンセルボタンの表示制御設定（将来的に有効化する可能性があるため設定として分離）
+  const ENABLE_CANCEL_BUTTON = false;
+
   // 48時間以内かどうかを判定する関数
   const isWithin48Hours = (dateString: string): boolean => {
     const transactionDate = new Date(dateString);
@@ -205,8 +208,8 @@ const TransactionHistory: React.FC<Props> = ({ transactions, onTransactionUpdate
                     合計: {transaction.total.toLocaleString()}円
                   </span>
                 )}
-                {/* 預入の場合はPDF出力ボタンを非表示、取引日当日の24時までも非表示、キャンセル済みも非表示 */}
-                {transaction.transaction_type !== '預入' && !isTransactionToday(transaction.date) && transaction.status !== "取消" && (
+                {/* PDF出力ボタン: 預入とキャンセル済み以外は常に表示 */}
+                {transaction.transaction_type !== '預入' && transaction.status !== "取消" && (
                   <TransactionPDFGenerator
                     transaction={transaction}
                     className="bg-red-600 text-white px-3 py-1 text-sm rounded hover:bg-red-700"
@@ -215,7 +218,8 @@ const TransactionHistory: React.FC<Props> = ({ transactions, onTransactionUpdate
                   />
                 )}
                 {/* 当日24時まで且つステータスが「取消」でない場合、且つ預入でない場合のみキャンセルボタンを表示 */}
-                {isTransactionToday(transaction.date) && transaction.status !== "取消" && transaction.transaction_type !== '預入' && (
+                {/* キャンセルボタン表示条件: ENABLE_CANCEL_BUTTON && isTransactionToday(transaction.date) && transaction.status !== "取消" && transaction.transaction_type !== '預入' */}
+                {ENABLE_CANCEL_BUTTON && isTransactionToday(transaction.date) && transaction.status !== "取消" && transaction.transaction_type !== '預入' && (
                   <button 
                     onClick={() => showCancelConfirmation(transaction.id)}
                     className="bg-gray-600 text-white px-3 py-1 text-sm rounded hover:bg-gray-700"

--- a/mt-dashboard-frontend/src/components/TimeRestrictedApp.tsx
+++ b/mt-dashboard-frontend/src/components/TimeRestrictedApp.tsx
@@ -41,7 +41,7 @@ const RestrictedPage: React.FC<{ timeInfo: TimeCheckResponse }> = ({ timeInfo })
         アクセス制限中
       </h1>
       <p className="text-gray-600 mb-4">
-        このサイトは11:05-24:00の間のみご利用いただけます。
+        このサイトは10:00-24:00の間のみご利用いただけます。
       </p>
     </div>
   </div>

--- a/mt-dashboard-frontend/src/components/WithdrawTransaction/WithdrawTransactionForm.tsx
+++ b/mt-dashboard-frontend/src/components/WithdrawTransaction/WithdrawTransactionForm.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { CircularProgress, useMediaQuery, useTheme } from '@mui/material';
 import ConfirmationModal from '../CashTransaction/ConfirmationModal';
+import { isTransactionButtonVisible } from '../../utils/timeRestriction';
 
 interface Metal {
   name: string;
@@ -43,6 +44,19 @@ const WithdrawTransactionForm: React.FC<WithdrawTransactionFormProps> = ({ metal
   const [isConfirmationOpen, setIsConfirmationOpen] = useState(false);
   const [isProcessing, setIsProcessing] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const [showTransactionButton, setShowTransactionButton] = useState(false);
+
+  // 時間制限チェックを定期的に実行
+  useEffect(() => {
+    const checkButtonVisibility = () => {
+      setShowTransactionButton(isTransactionButtonVisible());
+    };
+
+    checkButtonVisibility(); // 初回チェック
+    const interval = setInterval(checkButtonVisibility, 60000); // 1分ごとにチェック
+
+    return () => clearInterval(interval);
+  }, []);
 
   // 金とパラジウムのみをフィルタリングし、保有量が0より大きい金属のみを表示
   const filteredMetals = metals.filter(m => (m.name === 'Au' || m.name === 'Pd') && m.amount > 0);
@@ -375,14 +389,18 @@ const WithdrawTransactionForm: React.FC<WithdrawTransactionFormProps> = ({ metal
           </table>
         </div>
         <div className="flex justify-end mt-4">
-          <button
-            onClick={handleProceed}
-            className="px-4 py-2 bg-emerald-600 text-white rounded hover:bg-emerald-700"
-          >
-            返却手続きへ
-          </button>
+          {showTransactionButton && (
+            <button
+              onClick={handleProceed}
+              className="px-4 py-2 bg-emerald-600 text-white rounded hover:bg-emerald-700"
+            >
+              返却手続きへ
+            </button>
+          )}
         </div>
       </div>
+      
+      <div className="mt-2 text-left text-gray-500 text-xl font-bold">※現物返却は10:00〜12:30、14:30〜15:30の時間帯のみ利用可能です</div>
       
       <ConfirmationModal
         isOpen={isConfirmationOpen}

--- a/mt-dashboard-frontend/src/pages/LandingPage.tsx
+++ b/mt-dashboard-frontend/src/pages/LandingPage.tsx
@@ -53,7 +53,7 @@ const LandingPage = () => {
               ログイン
             </Button>
 
-            <Button 
+            {/* <Button 
               variant="outlined" 
               fullWidth 
               size="large"
@@ -61,7 +61,7 @@ const LandingPage = () => {
               sx={{ py: 1.5 }}
             >
               新規登録
-            </Button>
+            </Button> */}
           </Box>
         </Paper>
       </Container>

--- a/mt-dashboard-frontend/src/utils/timeRestriction.ts
+++ b/mt-dashboard-frontend/src/utils/timeRestriction.ts
@@ -11,6 +11,28 @@ export interface TimeCheckResponse {
   message: string;
 }
 
+// 取引ボタンの表示可否をチェックする関数
+export const isTransactionButtonVisible = (): boolean => {
+  const now = new Date();
+  
+  // 日本時間に変換（UTC+9）
+  const jstNow = new Date(now.getTime() + (9 * 60 * 60 * 1000));
+  const hour = jstNow.getHours();
+  const minute = jstNow.getMinutes();
+  
+  // 10:00-12:30の時間帯
+  if (hour === 10 || hour === 11 || (hour === 12 && minute <= 30)) {
+    return true;
+  }
+  
+  // 14:30-15:30の時間帯
+  if ((hour === 14 && minute >= 30) || (hour === 15 && minute <= 30)) {
+    return true;
+  }
+  
+  return false;
+};
+
 export const checkServerTime = async (): Promise<TimeCheckResponse> => {
   try {
     const response = await fetch(`${API_BASE_URL}/api/check-access-time`);
@@ -25,7 +47,7 @@ export const checkServerTime = async (): Promise<TimeCheckResponse> => {
       is_allowed: false,
       current_time: new Date().toISOString(),
       current_hour: new Date().getHours(),
-      allowed_hours: "11:05:00-24:00:00 (JST)",
+      allowed_hours: "10:00:00-24:00:00 (JST)",
       message: "時刻確認中にエラーが発生しました"
     };
   }


### PR DESCRIPTION
・ログイン可能時間変更
・決済可能時間でボタン表示、それ以外の時間で非表示
・決済可能時間の注意書き追加
・キャンセルボタン非表示、pdf出力を取引後すぐ表示させるようにした